### PR TITLE
Remove user_role foreign_key constraint to ref tables outside tenancy

### DIFF
--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -2,10 +2,12 @@ class Company < ActiveRecord::Base
   has_many :users_companies
   has_many :users, through: :users_companies
 
-  after_create :create_tenant
+  after_create :create_tenant, :delete_constraint
   after_destroy :destroy_tenant
 
   validates_presence_of :name, :subdomain
+
+  USER_ROLE_CONSTRAINT = 'fk_rails_318345354e'
 
   def create_tenant
     Apartment::Tenant.create(subdomain)
@@ -13,5 +15,9 @@ class Company < ActiveRecord::Base
 
   def destroy_tenant
     Apartment::Tenant.drop(subdomain)
+  end
+
+  def delete_constraint
+    ActiveRecord::Base.connection.execute("ALTER TABLE #{subdomain}.user_roles DROP CONSTRAINT #{USER_ROLE_CONSTRAINT};")
   end
 end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,3 +1,4 @@
 class Role < ActiveRecord::Base
-  has_many :users
+  has_many :user_role
+  has_many :users, through: :user_role
 end


### PR DESCRIPTION
https://github.com/influitive/apartment/issues/248
Execute delete_constraint after creating a tenancy in order to "fix" the
problem of not being able to reference User inside a tenant in
user_roles table.
It's more a workaround than a fix.
